### PR TITLE
Fix table headers in server-hardware.md

### DIFF
--- a/server-hardware.md
+++ b/server-hardware.md
@@ -26,7 +26,7 @@ When choosing cameras or a server, consult the [Buyers's Guide](/buyers-guide/) 
 
 The Raspberry Pi 4 and low performance NAS are not recommended for use with Scrypted NVR. Here are the baseline hardware recommendations:
 
-|Processor|Generation|
+|Operating System|CPU Generation|
 |-|-|
 |Windows|9th Generation (or equivalent for AMD)|
 |Linux|6th Generation (or equivalent for AMD)|


### PR DESCRIPTION
A quick fix for the headers of the "minimum CPU for each OS requirements" table; the OS column was incorrectly labeled "Processor"