### PR TITLE
Update Google Home doc to remove mention of app incompatibility

### DIFF
--- a/google-home.md
+++ b/google-home.md
@@ -1,6 +1,6 @@
 # Google Home
 
-Cameras imported into Scrypted can be streamed to the Google Home devices such as Chromecast, Android TV, and the Nest Hub.
+Cameras imported into Scrypted can be streamed to the Google Home devices such as Chromecast, Android TV, and the Nest Hub. Camera streaming is not supported by Google Home in the Google Home iOS app.
 
 <!--@include: ./parts/camera-preparation.md-->
 

--- a/google-home.md
+++ b/google-home.md
@@ -1,6 +1,6 @@
 # Google Home
 
-Cameras imported into Scrypted can be streamed to the Google Home devices such as Chromecast, Android TV, and the Nest Hub. Streaming to the Google Home app is currently not supported because the app does not support the WebRTC protocol.
+Cameras imported into Scrypted can be streamed to the Google Home devices such as Chromecast, Android TV, and the Nest Hub.
 
 <!--@include: ./parts/camera-preparation.md-->
 


### PR DESCRIPTION
The Google Home app has added support for WebRTC since the Google Home plugin page was last updated.

![Screenshot_20250420-200618](https://github.com/user-attachments/assets/58fa5c55-75d1-4430-ad15-38d42146b78d)
![Screenshot_20250420-200610](https://github.com/user-attachments/assets/752afc8e-4413-4303-b715-0d3186eb0c25)
![Screenshot_20250420-201655](https://github.com/user-attachments/assets/7fd6dff3-d757-4c99-83df-0ee9ae3738ab)

