### PR TITLE
Guide users to creating a directory on the disk mount point

### DIFF
--- a/scrypted-nvr/storage/mac.md
+++ b/scrypted-nvr/storage/mac.md
@@ -7,6 +7,8 @@ import ImagePopup from '../../src/ImagePopup.vue';
 ::: danger
 When creating a NVR Recordings folder on macOS, the folder name must end with `.noindex`. This prevents macOS Spotlight from indexing the folder. Spotlight's indexing of NVR Recordings will cause system instability and crashes. For example, if the NVR Recordings folder is currently `/Volumes/MyExternalDrive/scrypted-nvr`, rename it to `/Volumes/MyExternalDrive/scrypted-nvr.noindex` and then update the setting in the NVR plugin.
 
+Additionally, a directory should be created on the storage disk for video use.  MacOS will not honor the `.noindex` directive on the mount point itself.  The NVR Recording folder should be `/Volumes/MyExternalDrive/scrupted-nvr.noindex` and not `/Volumes/MyexternalDrive.noindex`
+
 Alternatively, add the drive or folder to the `Search Privacy` list in [macOS Spotlight settings](https://support.apple.com/guide/mac-help/prevent-spotlight-searches-in-files-mchl1bb43b84/mac).
 :::
 


### PR DESCRIPTION
Note added to inform users that MacOS will still try to index a volume when the volume name itself includes .noindex.  

While Scrypted can create the storage folders directly on the mount point, indexing will remain turned on whether .noindex or Search Privacy methods are used.