### PR TITLE
Add filesystem warning to Unraid storage page

### DIFF
--- a/scrypted-nvr/storage/unraid.md
+++ b/scrypted-nvr/storage/unraid.md
@@ -5,6 +5,10 @@ import ImagePopup from '../../src/ImagePopup.vue';
 
 # Unraid Storage
 
+::: warning Filesystem Requirement
+Scrypted NVR requires storage on an `ext4` or `xfs` filesystem (see [Docker Volume](/scrypted-nvr/storage/docker.html#manual-docker-setup)). Unraid's default `/mnt/user/` share paths use `shfs`, a FUSE userspace filesystem that pools multiple disks. Although the underlying disks may be formatted as XFS, Scrypted sees the FUSE layer rather than the native filesystem. This can cause recording failures due to how FUSE handles file operations used by the NVR recording system. See [koush/scrypted#2015](https://github.com/koush/scrypted/issues/2015) for details.
+:::
+
 1. Configure a Recordings storage path within Unraid. The `Host Path` is the path to the storage on the Unraid host. The provided `Container Path` (a chosen path in the container like `/nvr` or `/recordings`) will be used for the recordings storage directory.
 <!--@include: ./nvr-plugin-storage-settings.md-->
 


### PR DESCRIPTION
## Summary

- Add a warning to the Unraid storage page noting that Scrypted NVR requires `ext4` or `xfs`, and that Unraid's default `/mnt/user/` paths use `shfs` (FUSE) which can cause recording failures
- Links to the Docker storage page for the filesystem requirement and to koush/scrypted#2015 for details on the specific failure mode

## Context

The [Docker storage page](/scrypted-nvr/storage/docker.html#manual-docker-setup) documents the `ext4`/`xfs` requirement, but the Unraid page has no mention of it. Unraid's `/mnt/user/` share paths use `shfs`, a FUSE userspace filesystem that pools multiple disks. Although the underlying array disks are XFS, Scrypted sees the FUSE layer. The NVR's file truncation optimization for recycling inodes doesn't work correctly on FUSE, leading to recording interruptions across all cameras (documented in koush/scrypted#2015).