### PR TITLE
Update Gemini model recommendation 

### DIFF
--- a/llm.md
+++ b/llm.md
@@ -16,7 +16,7 @@ The following models are recommended for price and performance considerations:
 |----------|-------|
 | OpenAI | `gpt-5.4-nano` |
 | Anthropic | `claude-haiku-4-5` |
-| Gemini | `gemini-3.1-flash-lite-preview` |
+| Gemini | `gemini-3.1-flash-lite` |
 
 ## Local Model
 


### PR DESCRIPTION
Google have deprecated and are shutting down `gemini-3.1-flash-lite-preview` on the 9th of july 
(https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-1-flash-lite)

Update the recommended model to `gemini-3.1-flash-lite`