### PR TITLE
Docs: fix typo on System Page Validation

### DIFF
--- a/system-validation.md
+++ b/system-validation.md
@@ -48,7 +48,7 @@ IPv6 on the network and Scrypted server is recommended for optimal performance w
 
 ### Scrypted Server Address
 
-Specifying the `Scrypted Server Address` will affect how Scrypted advertises devices via the `HomeKit` plugin and how it communicates with other devices on th local network. Selecting a pair of wired ethernet addresses (one IPv4 and one IPv6) is recommended.
+Specifying the `Scrypted Server Address` will affect how Scrypted advertises devices via the `HomeKit` plugin and how it communicates with other devices on the local network. Selecting a pair of wired ethernet addresses (one IPv4 and one IPv6) is recommended.
 
 ### GPU Passthrough and GPU Decode
 


### PR DESCRIPTION
What this does: Fixes a small typo where "the" was missing an E (read as "th").

Where it was:

Page: System Validation
Link: https://docs.scrypted.app/system-validation.html Before:

...th...

After:

...the...

Context: Spotted this while reading the docs — thought it'd be worth fixing before anyone else got confused! Thanks for the great docs, by the way. 👍